### PR TITLE
Add link to README.md, pointing to https://snowpi.xyz

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # snowpirgb-python
+
+See [snowpi.xyz](https://snowpi.xyz) for setup instructions.


### PR DESCRIPTION
For people who have cloned the repo, it's handy to be able to get to the setup instructions easily.